### PR TITLE
HSS-hotfix: Make MME address configurable

### DIFF
--- a/db_docs/data_provisioning_users.sh
+++ b/db_docs/data_provisioning_users.sh
@@ -24,9 +24,11 @@ apn=$3
 key=$4
 no_of_users=$5
 cassandra_ip=$6
-if [ "$*" == "" -o $# -ne 6 ] ; then
-   echo -e "You must provide all of the arguments to the script\n"
-   echo -e "$0 <imsi> <msisdn> <apn> <key> <no_of_users> <cassandra_ip>\n"
+mmeidentity=${7:-'mme.localdomain'}
+mmerealm=${8:-'localdomain'}
+if [ "$*" == "" -o $# -lt 6 ] ; then
+   echo -e "You must provide all of the required arguments to the script\n"
+   echo -e "$0 <imsi> <msisdn> <apn> <key> <no_of_users> <cassandra_ip> [<mmeidentity> <mmerealm>]\n"
    exit
 fi
 
@@ -34,7 +36,7 @@ for (( i=1; i<=$no_of_users; i++ ))
 do
 	echo "IMSI=$imsi MSISDN=$msisdn"
 
-	cqlsh $cassandra_ip -e "INSERT INTO vhss.users_imsi (imsi, msisdn, access_restriction, key, mmehost, mmeidentity_idmmeidentity, mmerealm, rand, sqn, subscription_data) VALUES ('$imsi', $msisdn, 41, '$key', 'mme.localdomain', 3, 'localdomain', '2683b376d1056746de3b254012908e0e', 96, '{\"Subscription-Data\":{\"Access-Restriction-Data\":41,\"Subscriber-Status\":0,\"Network-Access-Mode\":2,\"Regional-Subscription-Zone-Code\":[\"0x0123\",\"0x4567\",\"0x89AB\",\"0xCDEF\",\"0x1234\",\"0x5678\",\"0x9ABC\",\"0xDEF0\",\"0x2345\",\"0x6789\"],\"MSISDN\":\"0x$msisdn\",\"AMBR\":{\"Max-Requested-Bandwidth-UL\":50000000,\"Max-Requested-Bandwidth-DL\":100000000},\"APN-Configuration-Profile\":{\"Context-Identifier\":0,\"All-APN-Configurations-Included-Indicator\":0,\"APN-Configuration\":{\"Context-Identifier\":0,\"PDN-Type\":0,\"Served-Party-IP-Address\":[\"10.0.0.1\",\"10.0.0.2\"],\"Service-Selection\":\"apn1\",\"EPS-Subscribed-QoS-Profile\":{\"QoS-Class-Identifier\":9,\"Allocation-Retention-Priority\":{\"Priority-Level\":15,\"Pre-emption-Capability\":0,\"Pre-emption-Vulnerability\":0}},\"AMBR\":{\"Max-Requested-Bandwidth-UL\":50000000,\"Max-Requested-Bandwidth-DL\":100000000},\"PDN-GW-Allocation-Type\":0,\"MIP6-Agent-Info\":{\"MIP-Home-Agent-Address\":[\"172.26.17.183\"]}}},\"Subscribed-Periodic-RAU-TAU-Timer\":0}}');"
+	cqlsh $cassandra_ip -e "INSERT INTO vhss.users_imsi (imsi, msisdn, access_restriction, key, mmehost, mmeidentity_idmmeidentity, mmerealm, rand, sqn, subscription_data) VALUES ('$imsi', $msisdn, 41, '$key', '$mmeidentity', 3, '$mmerealm', '2683b376d1056746de3b254012908e0e', 96, '{\"Subscription-Data\":{\"Access-Restriction-Data\":41,\"Subscriber-Status\":0,\"Network-Access-Mode\":2,\"Regional-Subscription-Zone-Code\":[\"0x0123\",\"0x4567\",\"0x89AB\",\"0xCDEF\",\"0x1234\",\"0x5678\",\"0x9ABC\",\"0xDEF0\",\"0x2345\",\"0x6789\"],\"MSISDN\":\"0x$msisdn\",\"AMBR\":{\"Max-Requested-Bandwidth-UL\":50000000,\"Max-Requested-Bandwidth-DL\":100000000},\"APN-Configuration-Profile\":{\"Context-Identifier\":0,\"All-APN-Configurations-Included-Indicator\":0,\"APN-Configuration\":{\"Context-Identifier\":0,\"PDN-Type\":0,\"Served-Party-IP-Address\":[\"10.0.0.1\",\"10.0.0.2\"],\"Service-Selection\":\"apn1\",\"EPS-Subscribed-QoS-Profile\":{\"QoS-Class-Identifier\":9,\"Allocation-Retention-Priority\":{\"Priority-Level\":15,\"Pre-emption-Capability\":0,\"Pre-emption-Vulnerability\":0}},\"AMBR\":{\"Max-Requested-Bandwidth-UL\":50000000,\"Max-Requested-Bandwidth-DL\":100000000},\"PDN-GW-Allocation-Type\":0,\"MIP6-Agent-Info\":{\"MIP-Home-Agent-Address\":[\"172.26.17.183\"]}}},\"Subscribed-Periodic-RAU-TAU-Timer\":0}}');"
 	if [ $? -ne 0 ];then
 	   echo -e "Oops! Something went wrong adding to vhss.users_imsi!\n"
 	   exit

--- a/hss/src/fdhss.cpp
+++ b/hss/src/fdhss.cpp
@@ -153,7 +153,8 @@ bool FDHss::init(hss_config_t * hss_config_p){
       fd_peer_validate_register (s6a_peer_validate);
 
       //TODO get the list of peers from the database
-      FDPeer *peer = new FDPeer( (char*)"mme.localdomain" );
+      char *mme = std::getenv("MME_IDENTITY");
+      FDPeer *peer = new FDPeer( mme ? mme : (char*)"mme.localdomain" );
       m_mme_peers.push_back( peer );
 
       if(!m_diameter.start()){


### PR DESCRIPTION
In dynamic environments the operator might want to be able to set the
DNS name of the MME and not hardcode it to be `mme.localdomain`. Until
this `//TODO get the list of peers from the database` is implemented we
should be able to at least set it through the environment.

`MME_IDENTITY` env variable needs to be set before running hss to use anything
other than `mme.localdomain`. Current behavior should continue if this
variable is not set.

Add optional positional arguments to accommodate customizing `MME_HOST`
and `MME_REALM` in `data_provisioning_users.sh`

Fixes: #1

Signed-off-by: Saikrishna Edupuganti <saikrishna.edupuganti@intel.com>
