### PR TITLE
PCRF crash due to lookup failures & other issues

### DIFF
--- a/pcrf/include/session.h
+++ b/pcrf/include/session.h
@@ -281,7 +281,12 @@ public:
 
    bool operator<( const GxSessionKey &rh ) const
    {
-      return m_imsi < rh.m_imsi ? true : m_apn < rh.m_apn;
+      //std::cout<<"\nLocal imsi "<<m_imsi<<" searching for "<<rh.m_imsi<<" Local apn "<<m_apn<<" searching for "<<rh.m_apn;
+      if(m_imsi < rh.m_imsi)
+        return true;
+      if ((m_imsi == rh.m_imsi) && ( m_apn < rh.m_apn))
+        return true;
+      return false;
    }
 
    GxSessionKey &operator=( const GxSessionKey &rh )
@@ -611,7 +616,7 @@ private:
    Subscriber m_subscriber;
 };
 
-class GxSessionMap : public std::map<const GxSessionKey,GxSession*>
+class GxSessionMap
 {
    friend GxSession;
 public:
@@ -629,6 +634,14 @@ public:
    bool isTerminating( GxSession *gx, bool lock = true );
 
    SMutex &getMutex() { return m_mutex; }
+   void printImsiApnMap()
+   {
+      for (auto i : m_imsiApn_session)
+      {
+          const GxSessionKey key=i.first;
+          std::cout <<"\nIMSI "<<key.getImsi()<<" APN "<<key.getApn();
+      }
+   }
 
 protected:
    void terminateSession( GxSession *gx );
@@ -638,6 +651,7 @@ private:
    GxSessionMap();
 
    SMutex m_mutex;
+   std::map<const GxSessionKey, GxSession*> m_imsiApn_session;
    std::set<GxSession*> m_sessions;
    std::map<std::string,GxSession*> m_sessionids;
    std::set<GxSession*> m_terminating;

--- a/pcrf/src/options.cpp
+++ b/pcrf/src/options.cpp
@@ -126,7 +126,7 @@ void PoliciesConfig::getDefaultRules( std::string& apn_name, std::list<DefaultRu
 		    			default_rule->setQci( config_rule->getQci() );
 		    			default_rule->setDefinition( config_rule->getDefinition() );
 		    		}
-                    std::cout<<"adding default rule "<<activation_rule_name << "\n";
+                    std::cout<<"\nAdding default rule "<<activation_rule_name;
                     default_rules.push_back(default_rule);
 		    	}
 		    }

--- a/pcrf/src/rule.cpp
+++ b/pcrf/src/rule.cpp
@@ -113,11 +113,11 @@ std::list<Rule*>::iterator RulesList::erase( std::list<Rule*>::iterator &it )
 void RulesList::addGxSession( GxSession *gx )
 {
    static int count;
-   std::cout<<"inside addSession for timer";
+   std::cout<<"\nInside addSession for timer IMSI "<<gx->getImsi();
    for ( auto r : m_rules ) {
       RuleTimer *tmr = r->getRuleTimer();
       if ( tmr != NULL) {
-         std::cout<<"calling addSession for "<<count <<" timer "<<tmr<<" \n";
+         std::cout<<"\nCalling addSession for "<<count <<" timer "<<tmr;
          tmr->addSession( gx );
       }
       count++;


### PR DESCRIPTION
PCRF crash was seen since map compare function was not correct
and map lookup was failing randomly. Also state variable was
static and there is not need to delete the state. This was
causing double free in PCRF code.