### PR TITLE
Context Replacement should clean DB entries

### DIFF
--- a/hss/prometheus/autocodegen.py
+++ b/hss/prometheus/autocodegen.py
@@ -1,7 +1,7 @@
 #
 # Copyright 2020-present Open Networking Foundation
 #
-# SPDX-License-Identifier: LicenseRef-ONF-Member-Only-1.0
+# SPDX-License-Identifier: Apache-2.0
 #
 
 #TODO Points

--- a/pcrf/include/dataaccess.h
+++ b/pcrf/include/dataaccess.h
@@ -61,6 +61,7 @@ public:
    bool addEndpoint( const Endpoint &ep );
 
    bool addSession( GxSession &s );
+   void deleteSessionForce(const std::string &imsi, const std::string &apn);
    void deleteSession( GxSession &s );
    bool sessionExists( const char *imsi, const char *apn );
    bool sessionExists( const std::string &imsi, const std::string &apn ) { return sessionExists( imsi.c_str(), apn.c_str() ); }
@@ -71,6 +72,10 @@ public:
    bool addSubscriberApn( const char *imsi, const SubscriberApn &sa );
    bool addSubscriberApn( const std::string &imsi, const SubscriberApn &sa ) { return addSubscriberApn( imsi.c_str(), sa ); }
    void deleteSubscriber( const Subscriber &s );
+   void deleteSubscriber(const std::string &imsi, const std::string &apn);
+   void deleteSessionIP(const std::string &imsi, const std::string &apn);
+   void deleteSessionBearer(const std::string &imsi, const std::string &apn, uint32_t ebi);
+   void deleteSession(const std::string imsi, const std::string apn);
 
 private:
    void _concatenateRules( const RulesList &rules, std::string &str );

--- a/pcrf/src/dataaccess.cpp
+++ b/pcrf/src/dataaccess.cpp
@@ -396,6 +396,13 @@ bool DataAccess::addSession( GxSession &s )
    return result;
 }
 
+void DataAccess::deleteSessionForce(const std::string &imsi, const std::string &apn)
+{
+      deleteSessionBearer( imsi, apn, 5);
+      deleteSessionIP(imsi, apn);
+      deleteSession(imsi,apn);
+}
+
 void DataAccess::deleteSession( GxSession &s )
 {
    for ( auto bearer : s.getBearers() )
@@ -477,6 +484,13 @@ void DataAccess::deleteSubscriber( const Subscriber &s )
    for ( auto const &pair : s.getApnPolicies() )
       _deleteSubscriberApn( s.getImsi().c_str(), pair.second->getApn().c_str() );
 }
+
+void DataAccess::deleteSubscriber( const std::string &imsi, const std::string &apn )
+{
+   _deleteSubscriber( imsi.c_str() );
+   _deleteSubscriberApn( imsi.c_str(), apn.c_str() );
+}
+
 
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
@@ -592,6 +606,25 @@ bool DataAccess::_addSessionBearer( const std::string &imsi, const std::string &
    return result;
 }
 
+void DataAccess::deleteSession(const std::string imsi, const std::string apn)
+{
+   std::stringstream ss;
+
+   ss << "DELETE FROM session WHERE "
+      << "imsi = '" << imsi << "' AND "
+      << "apn = '" << apn << "'";
+
+   SCassStatement stmt( ss.str().c_str() );
+
+   SCassFuture future = m_db.execute( stmt );
+
+   if ( future.errorCode() != CASS_OK )
+   {
+      Logger::system().error( "DataAccess::%s:%d - error %d executing [%s]",
+            __func__, __LINE__, future.errorCode(), ss.str().c_str() );
+   }
+}
+
 void DataAccess::_deleteSession( GxSession &s )
 {
    std::stringstream ss;
@@ -599,6 +632,25 @@ void DataAccess::_deleteSession( GxSession &s )
    ss << "DELETE FROM session WHERE "
       << "imsi = '" << s.getImsi() << "' AND "
       << "apn = '" << s.getApn() << "'";
+
+   SCassStatement stmt( ss.str().c_str() );
+
+   SCassFuture future = m_db.execute( stmt );
+
+   if ( future.errorCode() != CASS_OK )
+   {
+      Logger::system().error( "DataAccess::%s:%d - error %d executing [%s]",
+            __func__, __LINE__, future.errorCode(), ss.str().c_str() );
+   }
+}
+
+void DataAccess::deleteSessionIP(const std::string &imsi, const std::string &apn )
+{
+   std::stringstream ss;
+
+   ss << "DELETE FROM session_ip WHERE "
+      << "imsi = '" << imsi << "' AND "
+      << "apn = '" << apn << "'";
 
    SCassStatement stmt( ss.str().c_str() );
 
@@ -619,6 +671,27 @@ void DataAccess::_deleteSessionIP( const std::string &ip, const std::string &ims
       << "ip = '" << ip << "' AND "
       << "imsi = '" << imsi << "' AND "
       << "apn = '" << apn << "'";
+
+   SCassStatement stmt( ss.str().c_str() );
+
+   SCassFuture future = m_db.execute( stmt );
+
+   if ( future.errorCode() != CASS_OK )
+   {
+      Logger::system().error( "DataAccess::%s:%d - error %d executing [%s]",
+            __func__, __LINE__, future.errorCode(), ss.str().c_str() );
+   }
+}
+
+void DataAccess::deleteSessionBearer( const std::string &imsi, const std::string &apn, uint32_t ebi )
+{
+   std::stringstream ss;
+
+   ss << "DELETE FROM session_bearer WHERE "
+      << "imsi = '" << imsi << "' AND "
+      << "apn = '" << apn << "' AND "
+      << "ebi = " << ebi;
+
 
    SCassStatement stmt( ss.str().c_str() );
 

--- a/pcrf/src/session.cpp
+++ b/pcrf/src/session.cpp
@@ -1555,7 +1555,9 @@ void GxIpCan1::sendCCA()
 int GxIpCan1::cleanupSession( bool terminate )
 {
     Logger::gx().warn("%s:%d - terminate = %d ", __FUNCTION__,__LINE__, terminate);
-	// delete the Subscriber table which will internally delete SubscriberApn table.
+
+
+		// delete the Subscriber table which will internally delete SubscriberApn table.
 	GxSession* prevSession = NULL;
     if ( GxSessionMap::getInstance().findSession( getGxSession()->getImsi(), getGxSession()->getApn(), prevSession ) )
     {
@@ -1589,18 +1591,26 @@ int GxIpCan1::cleanupSession( bool terminate )
          Logger::gx().warn("Previous Session %p . Rules size after delete %d",prevSession, prevSession->getDefaultRuleList().size());
 
 	     Subscriber& subscriber = ( prevSession->getSubscriber() );
-		 getPCRF().dataaccess().deleteSubscriber( subscriber );
-	 
+         getPCRF().dataaccess().deleteSubscriber( subscriber );
+ 	 
     	 if ( getPCRF().dataaccess().sessionExists( prevSession->getImsi(), prevSession->getApn() ) )
     	 {
             getPCRF().dataaccess().deleteSession( *prevSession );
     	 }
-		 if( terminate == true )
+
+	     if( terminate == true )
 		 {
             Logger::gx().warn("Erasesession ***** %p", prevSession);
             GxSessionMap::getInstance().eraseSession( prevSession->getImsi(), prevSession->getApn() );
 		 }
-	 }
+	}
+    else if ( getPCRF().dataaccess().sessionExists( getGxSession()->getImsi(), getGxSession()->getApn() ) )
+    {
+        Logger::gx().warn("Session data not present in memory but in database imsi = %s", getGxSession()->getImsi().c_str());
+        getPCRF().dataaccess().deleteSessionForce(getGxSession()->getImsi(), getGxSession()->getApn());
+		getPCRF().dataaccess().deleteSubscriber( getGxSession()->getImsi(), getGxSession()->getApn());
+    }
+
      Logger::gx().warn("Return from %s",__FUNCTION__);
      return ValidateErrorCode::success;
 }


### PR DESCRIPTION
It was observed that partial DB entries was causing session setup
failure all the time and there was no way to bring PCRF out of
that state. Only PCRF restart could solve the problem of removing
all DB entries.